### PR TITLE
Potential fix for code scanning alert no. 5: Uncontrolled data used in path expression

### DIFF
--- a/main_archive.py
+++ b/main_archive.py
@@ -129,7 +129,15 @@ async def chat_query(
             raise HTTPException(status_code=400, detail="session_id is required when use_session_dirs=True")
 
         # Prepare FAISS index path
-        index_dir = os.path.join(FAISS_BASE, session_id) if use_session_dirs else FAISS_BASE  # type: ignore
+        if use_session_dirs:
+            index_dir = os.path.normpath(os.path.join(FAISS_BASE, session_id))
+            # Ensure index_dir is within FAISS_BASE
+            faiss_base_abs = os.path.abspath(FAISS_BASE)
+            index_dir_abs = os.path.abspath(index_dir)
+            if not index_dir_abs.startswith(faiss_base_abs + os.sep):
+                raise HTTPException(status_code=400, detail="Invalid session_id path")
+        else:
+            index_dir = FAISS_BASE  # type: ignore
         if not os.path.isdir(index_dir):
             raise HTTPException(status_code=404, detail=f"FAISS index not found at: {index_dir}")
 


### PR DESCRIPTION
Potential fix for [https://github.com/venkateshpabbati/document_portal/security/code-scanning/5](https://github.com/venkateshpabbati/document_portal/security/code-scanning/5)

The best way to fix the problem is to **normalize the constructed path and ensure it is constrained within the intended root directory (`FAISS_BASE`)**. This prevents directory traversal (e.g., `../../`) and absolute paths from escaping the base. The solution is to:
- When constructing `index_dir`, use `os.path.normpath(os.path.join(FAISS_BASE, session_id))` (if session dirs are in use),
- Ensure the normalized path starts with the safe base directory,
- If not, raise an HTTPException with an appropriate error message,
- Make these changes in `main_archive.py` around lines 132–134,
- No new external libraries are needed (Python’s built-in `os.path` suffices).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
