### PR TITLE
Potential fix for code scanning alert no. 6: Uncontrolled data used in path expression

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -135,7 +135,12 @@ async def chat_query(
             raise HTTPException(status_code=400, detail="session_id is required when use_session_dirs=True")
 
         index_dir = os.path.join(FAISS_BASE, session_id) if use_session_dirs else FAISS_BASE  # type: ignore
-        if not os.path.isdir(index_dir):
+        # Normalize and securely check index_dir for path traversal
+        abs_faiss_base = os.path.abspath(FAISS_BASE)
+        abs_index_dir = os.path.abspath(os.path.normpath(index_dir))
+        if not abs_index_dir.startswith(abs_faiss_base + os.sep) and abs_index_dir != abs_faiss_base:
+            raise HTTPException(status_code=400, detail="Invalid session_id or directory traversal attempt detected.")
+        if not os.path.isdir(abs_index_dir):
             raise HTTPException(status_code=404, detail=f"FAISS index not found at: {index_dir}")
 
         rag = ConversationalRAG(session_id=session_id)


### PR DESCRIPTION
Potential fix for [https://github.com/venkateshpabbati/document_portal/security/code-scanning/6](https://github.com/venkateshpabbati/document_portal/security/code-scanning/6)

To fix this vulnerability, we must ensure that any path constructed from user input cannot reference files or directories outside a designated base directory (`FAISS_BASE`). The best-practice fix is:

- Construct the candidate path as done now with `os.path.join`.
- Normalize the resulting path with `os.path.normpath` (to resolve any `..` or redundant slashes).
- **Critical:** Ensure the normalized path is either exactly equal to, or contained within, the base directory. Use `os.path.abspath` or `.resolve()` if using pathlib, then check that the resulting path starts with the (resolved) base directory path.
- If the check fails, reject the request with an error and do not perform any file/directory actions on the unchecked path.

The relevant changes are all in api/main.py. We will need to import nothing new, as all required modules are present. We will inject this check immediately after constructing `index_dir`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
