### PR TITLE
Potential fix for code scanning alert no. 5: Uncontrolled data used in path expression

### DIFF
--- a/main_archive.py
+++ b/main_archive.py
@@ -131,10 +131,10 @@ async def chat_query(
         # Prepare FAISS index path
         if use_session_dirs:
             index_dir = os.path.normpath(os.path.join(FAISS_BASE, session_id))
-            # Ensure index_dir is within FAISS_BASE
+            # Ensure index_dir is truly within FAISS_BASE
             faiss_base_abs = os.path.abspath(FAISS_BASE)
             index_dir_abs = os.path.abspath(index_dir)
-            if not index_dir_abs.startswith(faiss_base_abs + os.sep):
+            if os.path.commonpath([faiss_base_abs, index_dir_abs]) != faiss_base_abs:
                 raise HTTPException(status_code=400, detail="Invalid session_id path")
         else:
             index_dir = FAISS_BASE  # type: ignore


### PR DESCRIPTION
Potential fix for [https://github.com/venkateshpabbati/document_portal/security/code-scanning/5](https://github.com/venkateshpabbati/document_portal/security/code-scanning/5)

To fix the problem, we need to ensure that any `session_id` path provided by the user does not allow access outside the designated `FAISS_BASE` directory, regardless of user input. The single best way is to:
- Normalize the final path with `os.path.normpath` and resolve it to an absolute path with `os.path.abspath`.
- Verify with `os.path.commonpath([faiss_base_abs, index_dir_abs]) == faiss_base_abs` to ensure the resulting directory is truly within the allowed root, as this method is robust to bypasses that can defeat a simple string prefix check.
- Optionally, reject session_id values that are absolute paths or contain path separators, or sanitize further.

The code to fix is in the main_archive.py, specifically lines dealing with construction and checking of `index_dir` in the `/chat/query` endpoint handler. Changes include:
- Replace the manual `startswith` check with one using `os.path.commonpath`.
- Optionally, sanitize or further restrict session_id if more restrictive validation is desired.

No new library imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
